### PR TITLE
correct "fastSet" wrong usage in "writeStringToFile"

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -572,7 +572,7 @@ FileUtils::~FileUtils()
 bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string& fullPath)
 {
     Data data;
-    data.fastSet((unsigned char*)dataStr.c_str(), dataStr.size());
+    data.copy((unsigned char*)dataStr.c_str(), dataStr.size());
 
     bool rv = writeDataToFile(data, fullPath);
 


### PR DESCRIPTION
Cherry-pick from https://github.com/cocos-creator/cocos2d-x-lite/pull/1462

好像没有发现这个问题导致的崩溃，暂时不合并。